### PR TITLE
Add support for start and stop in transfer_to_memory (#1030) (#1189)

### DIFF
--- a/testsuite/AUTHORS
+++ b/testsuite/AUTHORS
@@ -71,6 +71,9 @@ Chronological list of authors
   - Fiona B. Naughton
   - Robert Delgado
 
+2017
+  - Utkarsh Bansal
+
 
 External code
 -------------

--- a/testsuite/CHANGELOG
+++ b/testsuite/CHANGELOG
@@ -14,7 +14,7 @@ and https://github.com/MDAnalysis/mdanalysis/wiki/UnitTests
 
 ------------------------------------------------------------------------------
 ??/??/16 jbarnoud, orbeckst, fiona-naughton, manuel.nuno.melo, richardjgowers
-         tyler.je.reddy
+         tyler.je.reddy, utkbansal
 
   * 0.16
     - added two unit tests for MDAnalysis.analysis.polymer

--- a/testsuite/MDAnalysisTests/core/test_universe.py
+++ b/testsuite/MDAnalysisTests/core/test_universe.py
@@ -356,7 +356,7 @@ class TestInMemoryUniverse(object):
                'DCD parser not available. Are you using python 3?')
     def test_reader_w_timeseries_frame_interval():
         universe = mda.Universe(PSF, DCD, in_memory=True,
-                                       in_memory_frame_interval=10)
+                                       in_memory_step=10)
         assert_equal(universe.trajectory.timeseries(universe.atoms).shape,
                      (3341, 10, 3),
                      err_msg="Unexpected shape of trajectory timeseries")
@@ -364,7 +364,7 @@ class TestInMemoryUniverse(object):
     @staticmethod
     def test_reader_wo_timeseries_frame_interval():
         universe = mda.Universe(GRO, TRR, in_memory=True,
-                                       in_memory_frame_interval=3)
+                                       in_memory_step=3)
         assert_equal(universe.trajectory.timeseries(universe.atoms).shape,
                      (47681, 4, 3),
                      err_msg="Unexpected shape of trajectory timeseries")
@@ -386,10 +386,78 @@ class TestInMemoryUniverse(object):
         universe1 = mda.Universe(PSF, DCD)
         array1 = universe1.trajectory.timeseries(skip=10)
         universe2 = mda.Universe(PSF, DCD, in_memory=True,
-                                        in_memory_frame_interval=10)
+                                        in_memory_step=10)
         array2 = universe2.trajectory.timeseries()
         assert_equal(array1, array2,
                      err_msg="Unexpected differences between arrays.")
+
+    @staticmethod
+    def test_slicing_with_start_stop():
+        universe = MDAnalysis.Universe(PDB_small, DCD)
+        # Skip only the last frame
+        universe.transfer_to_memory(start=10, stop=20)
+        assert_equal(universe.trajectory.timeseries(universe.atoms).shape,
+                     (3341, 10, 3),
+                     err_msg="Unexpected shape of trajectory timeseries")
+
+    @staticmethod
+    def test_slicing_without_start():
+        universe = MDAnalysis.Universe(PDB_small, DCD)
+        # Skip only the last frame
+        universe.transfer_to_memory(stop=10)
+        assert_equal(universe.trajectory.timeseries(universe.atoms).shape,
+                     (3341, 10, 3),
+                     err_msg="Unexpected shape of trajectory timeseries")
+
+    @staticmethod
+    def test_slicing_without_stop():
+        universe = MDAnalysis.Universe(PDB_small, DCD)
+        # Skip only the last frame
+        universe.transfer_to_memory(start=10)
+        print(universe.trajectory.timeseries(universe.atoms).shape)
+        assert_equal(universe.trajectory.timeseries(universe.atoms).shape,
+                     (3341, 88, 3),
+                     err_msg="Unexpected shape of trajectory timeseries")
+
+    @staticmethod
+    def test_slicing_step_without_start_stop():
+        universe = MDAnalysis.Universe(PDB_small, DCD)
+        # Skip only the last frame
+        universe.transfer_to_memory(step=2)
+        print(universe.trajectory.timeseries(universe.atoms).shape)
+        assert_equal(universe.trajectory.timeseries(universe.atoms).shape,
+                     (3341, 49, 3),
+                     err_msg="Unexpected shape of trajectory timeseries")
+
+    @staticmethod
+    def test_slicing_step_with_start_stop():
+        universe = MDAnalysis.Universe(PDB_small, DCD)
+        # Skip only the last frame
+        universe.transfer_to_memory(start=10, stop=30, step=2)
+        print(universe.trajectory.timeseries(universe.atoms).shape)
+        assert_equal(universe.trajectory.timeseries(universe.atoms).shape,
+                     (3341, 10, 3),
+                     err_msg="Unexpected shape of trajectory timeseries")
+
+    @staticmethod
+    def test_slicing_negative_start():
+        universe = MDAnalysis.Universe(PDB_small, DCD)
+        # Skip only the last frame
+        universe.transfer_to_memory(start=-10)
+        print(universe.trajectory.timeseries(universe.atoms).shape)
+        assert_equal(universe.trajectory.timeseries(universe.atoms).shape,
+                     (3341, 10, 3),
+                     err_msg="Unexpected shape of trajectory timeseries")
+
+    @staticmethod
+    def test_slicing_negative_stop():
+        universe = MDAnalysis.Universe(PDB_small, DCD)
+        # Skip only the last frame
+        universe.transfer_to_memory(stop=-20)
+        print(universe.trajectory.timeseries(universe.atoms).shape)
+        assert_equal(universe.trajectory.timeseries(universe.atoms).shape,
+                     (3341, 78, 3),
+                     err_msg="Unexpected shape of trajectory timeseries")
 
 
 class TestCustomReaders(object):


### PR DESCRIPTION
* Adds start & stop parameters to transfer_to_memory

* Rename frame_interval to step in transfer_to_memory

* Update docstrings

* Adds tests

* Adds more tests

* Update CHANGELOG and AUTHORS

* Rename usages of in_memory_frame_interval to in_memory_step

Fixes #

Changes made in this Pull Request:
 - 


PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?
